### PR TITLE
Add MLX port for Apple Silicon to Community Ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Input tensor is generated randomly in CPU pinned memory. both flash-kmeans and f
 ![benchmark large N](assets/benchmark_large.png)
 
 
+## Community Ports
+
+- [flash-kmeans-mlx](https://github.com/hanxiao/flash-kmeans-mlx) - Pure MLX port for Apple Silicon (M-series GPU), up to 94x faster than sklearn.
+
 ## Citation
 
 If you use this codebase, or otherwise found our work valuable, please cite:


### PR DESCRIPTION
Great work on Flash-KMeans! The IO-aware batched K-Means design and the Triton kernels are really impressive.

I ported it to pure MLX for Apple Silicon (M-series GPU) so it can run natively on Mac without CUDA. The port preserves the same batched API (`batch_kmeans_Euclid`, `batch_kmeans_Cosine`, `batch_kmeans_Dot`, `FlashKMeans` class) and has been verified against sklearn with identical initial centroids (inertia difference <0.01%).

Repo: https://github.com/hanxiao/flash-kmeans-mlx

This PR adds a small "Community Ports" section to the README linking to the MLX port.