### PR TITLE
Add MLX community port for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ If you use this codebase, or otherwise found our work valuable, please cite:
   year={2025}
 }
 ```
+
+## Community Ports
+
+- **[flash-kmeans-mlx](https://github.com/hanxiao/flash-kmeans-mlx)** - Apple Silicon port using MLX. Pure MLX, no PyTorch dependency. 500K points clustered in 77ms on M3 Ultra (517x faster than sklearn).


### PR DESCRIPTION
## flash-kmeans-mlx

Apple Silicon port of Flash-KMeans using [MLX](https://github.com/ml-explore/mlx). Pure MLX, no PyTorch dependency.

**Repo**: [hanxiao/flash-kmeans-mlx](https://github.com/hanxiao/flash-kmeans-mlx)

### Key optimizations

- Custom Metal kernel for argmax (2.6x faster than mx.argmax)
- mx.addmm fused bias+matmul for distance computation
- Multi-iteration mx.compile for cross-iteration optimization
- Float16 assignment with float32 centroid accumulation

### MLX vs sklearn (M3 Ultra)

| N | D | K | Iters | MLX | sklearn | Speedup |
|---|---|---|-------|-----|---------|---------|
| 5K | 64 | 50 | 10 | 2ms | 34ms | 17x |
| 50K | 128 | 256 | 20 | 7ms | 1.28s | 183x |
| 100K | 128 | 1000 | 20 | 32ms | 9.8s | 306x |
| 500K | 128 | 1000 | 10 | 77ms | 39.8s | 517x |

### vs H200 GPU (FP16, D=128, 100 iterations)

![H200 vs M3 Ultra benchmark](https://raw.githubusercontent.com/hanxiao/flash-kmeans-mlx/main/assets/h200-vs-mlx-benchmark.png)

MLX on M3 Ultra matches or beats naive PyTorch methods running on H200. The remaining gap to the Triton kernel maps to the 37x raw compute difference between M3 Ultra AMX (27 TFLOPS) and H200 Tensor Cores (990 TFLOPS).

This PR adds a Community Ports section to the README linking to the MLX port.