### PR TITLE
Bug fix for cosine/dot kmeans can return cluster_id == n_clusters

### DIFF
--- a/flash_kmeans/assign_euclid_triton.py
+++ b/flash_kmeans/assign_euclid_triton.py
@@ -604,8 +604,12 @@ def _cosine_assign_kernel(
         # Compute cosine distance (BLOCK_N, BLOCK_K) = x_tile @ c_tile
         cross = tl.dot(x_tile, c_tile).to(tl.float32)  # float32
 
-        # Mask out invalid centroid columns before reduction
-        dist = tl.where(k_mask[None, :], cross, 0.0)
+        # Mask out invalid centroid columns before reduction.
+        # Use a sentinel below any real cosine/dot score so masked tail lanes
+        # never win the argmax. (0.0 is a real cosine value: any input row whose
+        # cosine to all real centroids is < 0 would otherwise route to a masked
+        # lane, returning an out-of-range cluster id.)
+        dist = tl.where(k_mask[None, :], cross, -torch.finfo(torch.float32).max)
 
         curr_max = tl.max(dist, axis=1)
         curr_idx = tl.argmax(dist, axis=1)


### PR DESCRIPTION
Root cause is for the cosine/dot path, the triton kernel use 0.0 to mask OOB items. However, 0.0 is a valid score for cosine/dot.

To repro this bug,
```
import torch                                                                                                                                                 
from flash_kmeans import batch_kmeans_Cosine                                                                                                                 
                                                                                                                                                             
bad = []                                                                                                                                                     
for seed in range(8):                                                                                                                                        
    torch.manual_seed(seed)                                                                                                                                  
    x = torch.randn(1, 500, 64, device="cuda", dtype=torch.float16)                                                                                          
    ids, _, _ = batch_kmeans_Cosine(x, n_clusters=4, max_iters=20)                                                                                           
    if ids.max().item() >= 4:                                                                                                                                
        bad.append((seed, ids.max().item()))                                                                                                                 
                                                                                                                                                             
print(f"misfired seeds (id == n_clusters returned): {bad}")                                                                                                  
assert not bad, f"out-of-range cluster ids for {len(bad)} of 8 seeds"
```
Example output:
```
misfired seeds (id == n_clusters returned): [(0, 4), (2, 4), (6, 4), (7, 4)]
Traceback (most recent call last):
  File "kmeans_bug.py", line 13, in <module>
    assert not bad, f"out-of-range cluster ids for {len(bad)} of 8 seeds" 
           ^^^^^^^
AssertionError: out-of-range cluster ids for 4 of 8 seeds
```